### PR TITLE
Updating to use latest SURF QSFP I2C python device

### DIFF
--- a/python/epix_hr_core/_SysReg.py
+++ b/python/epix_hr_core/_SysReg.py
@@ -43,7 +43,7 @@ class SysReg(pr.Device):
             enabled  = (not sim),
         ))
 
-        self.add(optics.Sff8472(
+        self.add(optics.Qsfp(
             name    = 'QSfpI2C',
             offset  = 0x03000000,
             enabled = (not sim),

--- a/ruckus.tcl
+++ b/ruckus.tcl
@@ -7,7 +7,7 @@ if { [VersionCheck 2020.1] < 0 } {exit -1}
 # Check for submodule tagging
 if { [info exists ::env(OVERRIDE_SUBMODULE_LOCKS)] != 1 || $::env(OVERRIDE_SUBMODULE_LOCKS) == 0 } {
    if { [SubmoduleCheck {ruckus} {3.0.1}  ] < 0 } {exit -1}
-   if { [SubmoduleCheck {surf}   {2.18.1} ] < 0 } {exit -1}
+   if { [SubmoduleCheck {surf}   {2.24.0} ] < 0 } {exit -1}
 } else {
    puts "\n\n*********************************************************"
    puts "OVERRIDE_SUBMODULE_LOCKS != 0"


### PR DESCRIPTION
### Description
- updating surf version lock to v2.24.0 (or later)
- updating SW from optics.Sff8472 to optics.Qsfp