### PR TITLE
Fixed DS2411 adding pullup constraint on the comm pins

### DIFF
--- a/core/xdc/epix-hr/EpixHrCore.xdc
+++ b/core/xdc/epix-hr/EpixHrCore.xdc
@@ -16,6 +16,9 @@
 
 set_property -dict {PACKAGE_PIN AB16 IOSTANDARD LVCMOS33} [get_ports snIoAdcCard]
 set_property -dict {PACKAGE_PIN AF13 IOSTANDARD LVCMOS25} [get_ports snIoCarrier]
+set_property PULLUP TRUE [get_ports snIoAdcCard]
+set_property PULLUP TRUE [get_ports snIoCarrier]
+
 
 # QSFP Ports
 


### PR DESCRIPTION
DS2411 is used in the HR Analog Card and in the HR carrier boards in order to give a digital serial number to both of these PCBs.

The component's 1-wire communication needs a weak pull up resistor in order to work.
https://datasheets.maximintegrated.com/en/ds/DS2411.pdf

Given the lack of pull-up in HW, a pull-up constraint have been added in the xdc.

TODO: add the pull-up resistor in the future iterations of the PCBs.