### PR TITLE
Unify trigControlAXI

### DIFF
--- a/python/epix_hr_core/_TriggerRegisters.py
+++ b/python/epix_hr_core/_TriggerRegisters.py
@@ -26,15 +26,17 @@ class TriggerRegisters(pr.Device):
 
         #Setup registers & variables
 
-        self.add(pr.RemoteVariable(name='RunTriggerEnable',description='RunTriggerEnable',  offset=0x00000000, bitSize=1,  bitOffset=0, base=pr.Bool, mode='RW'))
-        self.add(pr.RemoteVariable(name='RunTriggerDelay', description='RunTriggerDelay',   offset=0x00000004, bitSize=32, bitOffset=0, base=pr.UInt, disp = '{}', mode='RW'))
-        self.add(pr.RemoteVariable(name='DaqTriggerEnable',description='DaqTriggerEnable',  offset=0x00000008, bitSize=1,  bitOffset=0, base=pr.Bool, mode='RW'))
-        self.add(pr.RemoteVariable(name='DaqTriggerDelay', description='DaqTriggerDelay',   offset=0x0000000C, bitSize=32, bitOffset=0, base=pr.UInt, disp = '{}', mode='RW'))
-        self.add(pr.RemoteVariable(name='AutoRunEn',       description='AutoRunEn',         offset=0x00000010, bitSize=1,  bitOffset=0, base=pr.Bool, mode='RW'))
-        self.add(pr.RemoteVariable(name='AutoDaqEn',       description='AutoDaqEn',         offset=0x00000014, bitSize=1,  bitOffset=0, base=pr.Bool, mode='RW'))
-        self.add(pr.RemoteVariable(name='AutoTrigPeriod',  description='AutoTrigPeriod',    offset=0x00000018, bitSize=32, bitOffset=0, base=pr.UInt, disp = '{}', mode='RW'))
-        self.add(pr.RemoteVariable(name='PgpTrigEn',       description='PgpTrigEn',         offset=0x0000001C, bitSize=1,  bitOffset=0, base=pr.Bool, mode='RW'))
-        self.add(pr.RemoteVariable(name='AcqCount',        description='AcqCount',          offset=0x00000024, bitSize=32, bitOffset=0, base=pr.UInt, disp = '{}', mode='RO'))
+        self.add(pr.RemoteVariable(name='RunTriggerEnable',      description='RunTriggerEnable',  offset=0x00000000, bitSize=1,  bitOffset=0, base=pr.Bool, mode='RW'))
+        self.add(pr.RemoteVariable(name='TimingRunTriggerEnable',description='RunTriggerEnable',  offset=0x00000000, bitSize=1,  bitOffset=1, base=pr.Bool, mode='RW'))
+        self.add(pr.RemoteVariable(name='RunTriggerDelay',       description='RunTriggerDelay',   offset=0x00000004, bitSize=32, bitOffset=0, base=pr.UInt, disp = '{}', mode='RW'))
+        self.add(pr.RemoteVariable(name='DaqTriggerEnable',      description='DaqTriggerEnable',  offset=0x00000008, bitSize=1,  bitOffset=0, base=pr.Bool, mode='RW'))
+        self.add(pr.RemoteVariable(name='TimingDaqTriggerEnable',description='DaqTriggerEnable',  offset=0x00000008, bitSize=1,  bitOffset=1, base=pr.Bool, mode='RW'))
+        self.add(pr.RemoteVariable(name='DaqTriggerDelay',       description='DaqTriggerDelay',   offset=0x0000000C, bitSize=32, bitOffset=0, base=pr.UInt, disp = '{}', mode='RW'))
+        self.add(pr.RemoteVariable(name='AutoRunEn',             description='AutoRunEn',         offset=0x00000010, bitSize=1,  bitOffset=0, base=pr.Bool, mode='RW'))
+        self.add(pr.RemoteVariable(name='AutoDaqEn',             description='AutoDaqEn',         offset=0x00000014, bitSize=1,  bitOffset=0, base=pr.Bool, mode='RW'))
+        self.add(pr.RemoteVariable(name='AutoTrigPeriod',        description='AutoTrigPeriod',    offset=0x00000018, bitSize=32, bitOffset=0, base=pr.UInt, disp = '{}', mode='RW'))
+        self.add(pr.RemoteVariable(name='PgpTrigEn',             description='PgpTrigEn',         offset=0x0000001C, bitSize=1,  bitOffset=0, base=pr.Bool, mode='RW'))
+        self.add(pr.RemoteVariable(name='AcqCount',              description='AcqCount',          offset=0x00000024, bitSize=32, bitOffset=0, base=pr.UInt, disp = '{}', mode='RO'))
 
 
         #####################################

--- a/shared/rtl/TrigControlAxi.vhd
+++ b/shared/rtl/TrigControlAxi.vhd
@@ -33,24 +33,28 @@ entity TrigControlAxi is
    );
    port (
       -- Trigger outputs
-      appClk        : in  sl;
-      appRst        : in  sl;
-      acqStart      : out sl;
-      dataSend      : out sl;
-
+      appClk            : in  sl;
+      appRst            : in  sl;
+      acqStart          : out sl;
+      dataSend          : out sl;
+      
       -- External trigger inputs
-      runTrigger    : in  sl;
-      daqTrigger    : in  sl;
-
+      runTrigger        : in  sl;
+      daqTrigger        : in  sl;
+      
       -- PGP clocks and reset
-      sysClk        : in  sl;
-      sysRst     : in  sl;
+      sysClk            : in  sl;
+      sysRst            : in  sl;
       -- Software trigger
-      ssiCmd        : in  SsiCmdMasterType;
+      ssiCmd            : in  SsiCmdMasterType;
       -- Fiber optic trigger
-      pgpRxOut      : in  Pgp2bRxOutType;
+      pgpRxOut          : in  Pgp2bRxOutType;
       -- Fiducial code output
-      opCodeOut     : out slv(7 downto 0);
+      opCodeOut         : out slv(7 downto 0);
+
+      -- Timing Triggers
+      timingRunTrigger  : in sl := '0';
+      timingDaqTrigger  : in sl := '0';
 
       -- AXI lite slave port for register access
       axilClk           : in  sl;
@@ -72,6 +76,8 @@ architecture rtl of TrigControlAxi is
       pgpTrigEn         : sl;
       autoRunEn         : sl;
       autoDaqEn         : sl;
+      timingRunEn       : sl;
+      timingDaqEn       : sl;
       acqCountReset     : sl;
       runTriggerDelay   : slv(31 downto 0);
       daqTriggerDelay   : slv(31 downto 0);
@@ -84,6 +90,8 @@ architecture rtl of TrigControlAxi is
       pgpTrigEn         => '0',
       autoRunEn         => '0',
       autoDaqEn         => '0',
+      timingRunEn       => '0',
+      timingDaqEn       => '0',
       acqCountReset     => '0',
       runTriggerDelay   => (others=>'0'),
       daqTriggerDelay   => (others=>'0'),
@@ -130,8 +138,8 @@ architecture rtl of TrigControlAxi is
    signal autoDaqEn     : std_logic;
 
    -- Op code signals
-   signal syncOpCode : slv(7 downto 0);
-
+   signal syncOpCode : slv(7 downto 0) := (others => '0');
+   
    signal trigSync : TriggerType;
 
 begin
@@ -221,9 +229,9 @@ begin
    --------------------------------------------------
    -- Combine with TTL triggers and look for edges --
    --------------------------------------------------
-   combinedRunTrig <= (coreSidebandRun and r.trig.pgpTrigEn) or (runTrigger and not r.trig.pgpTrigEn);
-   combinedDaqTrig <= (coreSidebandDaq and r.trig.pgpTrigEn) or (daqTrigger and not r.trig.pgpTrigEn);
-
+   combinedRunTrig <= (coreSidebandRun and r.trig.pgpTrigEn) or (runTrigger and not r.trig.pgpTrigEn) or (timingRunTrigger and r.trig.timingRunEn);
+   combinedDaqTrig <= (coreSidebandDaq and r.trig.pgpTrigEn) or (daqTrigger and not r.trig.pgpTrigEn) or (timingDaqTrigger and r.trig.timingDaqEn);
+   
    --------------------------------
    -- Run Input
    --------------------------------
@@ -395,8 +403,10 @@ begin
       axiSlaveWaitTxn(regCon, sAxilWriteMaster, sAxilReadMaster, v.sAxilWriteSlave, v.sAxilReadSlave);
 
       axiSlaveRegister (regCon, x"00", 0, v.trig.runTriggerEnable);
+      axiSlaveRegister (regCon, x"00", 1, v.trig.timingRunEn);
       axiSlaveRegister (regCon, x"04", 0, v.trig.runTriggerDelay);
       axiSlaveRegister (regCon, x"08", 0, v.trig.daqTriggerEnable);
+      axiSlaveRegister (regCon, x"08", 1, v.trig.timingDaqEn);
       axiSlaveRegister (regCon, x"0C", 0, v.trig.daqTriggerDelay);
       axiSlaveRegister (regCon, x"10", 0, v.trig.autoRunEn);
       axiSlaveRegister (regCon, x"14", 0, v.trig.autoDaqEn);


### PR DESCRIPTION
While integrating the trigControlAXI module with the 2M project (using the 10K project as base), I discovered that there are several versions of this file. Attempted to unify them, and the 2M project will be using the trigControlAxi from the epix-hr-core submodule.