### PR TITLE
Fix Mon ADC register Bug

### DIFF
--- a/python/epix_hr_core/_MonAdcRegisters.py
+++ b/python/epix_hr_core/_MonAdcRegisters.py
@@ -96,4 +96,4 @@ class MonAdcRegisters(pr.Device):
 
     @staticmethod
     def getDelay(var, read):
-        return var.dependencies[0].get(read)
+        return var.dependencies[0].get()


### PR DESCRIPTION
Dependency get method does not seem to recieve any parameter in rogue v5.15.3. Removed parameter.