### PR TITLE
adding pcieDaqTrigPause output

### DIFF
--- a/comm/pgp2b/rtl/EpixHrComm.vhd
+++ b/comm/pgp2b/rtl/EpixHrComm.vhd
@@ -38,6 +38,7 @@ entity EpixHrComm is
       ROGUE_SIM_EN_G       : boolean                     := false;
       ROGUE_SIM_PORT_NUM_G : natural range 1024 to 49151 := 11000);
    port (
+      pcieDaqTrigPause : out sl;
       -- Debug AXI-Lite Interface
       axilReadMaster   : in  AxiLiteReadMasterType;
       axilReadSlave    : out AxiLiteReadSlaveType;
@@ -107,6 +108,9 @@ architecture mapping of EpixHrComm is
    signal outMuxTxSlave  : AxiStreamSlaveType;
 
 begin
+
+   -- Mapping the trigPauses from one of the PGP "DATA" lanes (they are all identical)
+   pcieDaqTrigPause <= pgpRxOut(0).remLinkData(0);
 
   U_SyncTrig1 : entity surf.SynchronizerOneShot
       generic map (

--- a/comm/pgp3/rtl/EpixHrComm.vhd
+++ b/comm/pgp3/rtl/EpixHrComm.vhd
@@ -39,6 +39,7 @@ entity EpixHrComm is
       ROGUE_SIM_EN_G       : boolean                     := false;
       ROGUE_SIM_PORT_NUM_G : natural range 1024 to 49151 := 11000);
    port (
+      pcieDaqTrigPause : out sl;
       -- Debug AXI-Lite Interface
       axilReadMaster   : in  AxiLiteReadMasterType;
       axilReadSlave    : out AxiLiteReadSlaveType;
@@ -116,6 +117,9 @@ architecture mapping of EpixHrComm is
    signal outMuxTxSlave  : AxiStreamSlaveType;
 
 begin
+
+   -- Mapping the trigPauses from one of the PGP "DATA" lanes (they are all identical)
+   pcieDaqTrigPause <= pgpRxOut(0).remLinkData(0);
 
   U_SyncTrig1 : entity surf.SynchronizerOneShot
       generic map (

--- a/comm/pgp4/rtl/EpixHrComm.vhd
+++ b/comm/pgp4/rtl/EpixHrComm.vhd
@@ -40,6 +40,7 @@ entity EpixHrComm is
       ROGUE_SIM_EN_G       : boolean                     := false;
       ROGUE_SIM_PORT_NUM_G : natural range 1024 to 49151 := 11000);
    port (
+      pcieDaqTrigPause : out sl;
       -- Debug AXI-Lite Interface
       axilReadMaster   : in  AxiLiteReadMasterType;
       axilReadSlave    : out AxiLiteReadSlaveType;
@@ -117,6 +118,9 @@ architecture mapping of EpixHrComm is
    signal outMuxTxSlave  : AxiStreamSlaveType;
 
 begin
+
+   -- Mapping the trigPauses from one of the PGP "DATA" lanes (they are all identical)
+   pcieDaqTrigPause <= pgpRxOut(0).remLinkData(0);
 
   U_SyncTrig1 : entity surf.SynchronizerOneShot
       generic map (

--- a/core/rtl/EpixHrCore.vhd
+++ b/core/rtl/EpixHrCore.vhd
@@ -43,6 +43,7 @@ entity EpixHrCore is
       ----------------------
       -- Top Level Interface
       ----------------------
+      pcieDaqTrigPause : out sl;
       -- System Clock and Reset
       sysClk           : out   sl;
       sysRst           : out   sl;
@@ -288,6 +289,7 @@ begin
          ROGUE_SIM_EN_G       => ROGUE_SIM_EN_G,
          ROGUE_SIM_PORT_NUM_G => ROGUE_SIM_PORT_NUM_G)
       port map (
+         pcieDaqTrigPause => pcieDaqTrigPause,
          -- Debug AXI-Lite Interface
          axilReadMaster   => axilReadMasters(COMM_INDEX_C),
          axilReadSlave    => axilReadSlaves(COMM_INDEX_C),


### PR DESCRIPTION
### Description
- Mapping the DAQ pause from the backend DDR/HBM buffer
- https://github.com/slaclab/lcls2-pgp-fw-lib/blob/v5.10.0/shared/rtl/UltraScale/Pgp4Lane.vhd#L112