### PR TITLE
enable setting slow DAC voltage in human readable format from the client

### DIFF
--- a/python/epix_hr_core/_sDacRegisters.py
+++ b/python/epix_hr_core/_sDacRegisters.py
@@ -35,11 +35,11 @@ class sDacRegisters(pr.Device):
             pr.RemoteVariable(name='dummy'  ,         description='',                  offset=0x00014, bitSize=32,   bitOffset=0,   base=pr.UInt, disp = '{:#x}', mode='RW'))
         )
         self.add((
-            pr.LinkVariable  (name='Vdac_0' ,         linkedGet=self.convtFloat,        dependencies=[self.dac_0]),
-            pr.LinkVariable  (name='Vdac_1' ,         linkedGet=self.convtFloat,        dependencies=[self.dac_1]),
-            pr.LinkVariable  (name='Vdac_2' ,         linkedGet=self.convtFloat,        dependencies=[self.dac_2]),
-            pr.LinkVariable  (name='Vdac_3' ,         linkedGet=self.convtFloat,        dependencies=[self.dac_3]),
-            pr.LinkVariable  (name='Vdac_4' ,         linkedGet=self.convtFloat,        dependencies=[self.dac_4]))
+            pr.LinkVariable  (name='Vdac_0' ,        linkedSet=self.revConvtFloat,     linkedGet=self.convtFloat,        dependencies=[self.dac_0]),
+            pr.LinkVariable  (name='Vdac_1' ,        linkedSet=self.revConvtFloat,     linkedGet=self.convtFloat,        dependencies=[self.dac_1]),
+            pr.LinkVariable  (name='Vdac_2' ,        linkedSet=self.revConvtFloat,     linkedGet=self.convtFloat,        dependencies=[self.dac_2]),
+            pr.LinkVariable  (name='Vdac_3' ,        linkedSet=self.revConvtFloat,     linkedGet=self.convtFloat,        dependencies=[self.dac_3]),
+            pr.LinkVariable  (name='Vdac_4' ,        linkedSet=self.revConvtFloat,     linkedGet=self.convtFloat,        dependencies=[self.dac_4]))
         )
 
         #####################################
@@ -58,6 +58,12 @@ class sDacRegisters(pr.Device):
         value   = var.dependencies[0].get(read=False)
         fpValue = value*(3.0/65536.0)
         return '%0.3f'%(fpValue)
+
+    @staticmethod
+    def revConvtFloat(dev, var):
+        value   = var.dependencies[0].set(read=False)
+        intValue = int(value*(65536.0/3.0))
+        return '%d'%(intValue)
 
     @staticmethod
     def frequencyConverter(self):

--- a/python/epix_hr_core/_sDacRegisters.py
+++ b/python/epix_hr_core/_sDacRegisters.py
@@ -63,7 +63,7 @@ class sDacRegisters(pr.Device):
     def revConvtFloat(dev, var):
         value   = var.dependencies[0].set(read=False)
         intValue = int(value*(65536.0/3.0))
-        return '%d'%(intValue)
+        return '%04x' % (intValue)
 
     @staticmethod
     def frequencyConverter(self):


### PR DESCRIPTION
Add set ability for `Vdac_* `
Was it correct to return an int: `return '%d'%(intValue)`
and not a 2-byte hex? `return '%04x'%(intValue)`
The GUI field shows hex:
![image](https://github.com/user-attachments/assets/bbd4ebbb-232e-4214-a6f0-fcb525ed5b3e)
