### PR TITLE
Actually enable setting slow DAC voltage in human readable format from the client

### DIFF
--- a/python/epix_hr_core/_sDacRegisters.py
+++ b/python/epix_hr_core/_sDacRegisters.py
@@ -1,4 +1,4 @@
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 # This file is part of the 'EPIX HR Firmware'. It is subject to
 # the license terms in the LICENSE.txt file found in the top-level directory
 # of this distribution and at:
@@ -6,12 +6,13 @@
 # No part of the 'EPIX HR Firmware', including this file, may be
 # copied, modified, propagated, or distributed except according to the terms
 # contained in the LICENSE.txt file.
-#-----------------------------------------------------------------------------
-import pyrogue     as pr
+# -----------------------------------------------------------------------------
+import pyrogue as pr
+
 
 class sDacRegisters(pr.Device):
     def __init__(self, **kwargs):
-        super().__init__(description='Slow DAC Registers', **kwargs)
+        super().__init__(description="Slow DAC Registers", **kwargs)
 
         # Creation. memBase is either the register bus server (srp, rce mapped memory, etc) or the device which
         # contains this object. In most cases the parent and memBase are the same but they can be
@@ -23,41 +24,48 @@ class sDacRegisters(pr.Device):
         # Create block / variable combinations
         #############################################
 
-
         # Setup registers & variables
 
         # Add Five DAC Registers
         for i in range(5):
-            self.add(pr.RemoteVariable(
-                name = f'dac_{i}',
-                offset = i * 4,
-                bitSize = 16,
-                bitOffset = 0,
-                base = pr.UInt,
-                disp = '{:#x}',
-                mode = 'RW'))
-        
+            self.add(
+                pr.RemoteVariable(
+                    name=f"dac_{i}",
+                    offset=i * 4,
+                    bitSize=16,
+                    bitOffset=0,
+                    base=pr.UInt,
+                    disp="{:#x}",
+                    mode="RW",
+                )
+            )
+
         # Add Dummy Register
-        self.add(pr.RemoteVariable(
-        name = 'dummy',
-        description = '',
-        offset = 0x00014,
-        bitSize = 32,
-        bitOffset = 0,
-        base = pr.UInt,
-        disp = '{:#x}',
-        mode = 'RW'))
+        self.add(
+            pr.RemoteVariable(
+                name="dummy",
+                description="",
+                offset=0x00014,
+                bitSize=32,
+                bitOffset=0,
+                base=pr.UInt,
+                disp="{:#x}",
+                mode="RW",
+            )
+        )
 
         # Add DAC Voltage Linker Variables
         for i in range(5):
-            self.add(pr.LinkVariable(
-                name = f'Vdac_{i}',
-                units = 'V',
-                disp = '{:1.3f}', # Only display the 1st 3 decimal points
-                linkedGet = self.convtFloat,
-                linkedSet = self.revConvtFloat,
-                dependencies = [self.variables[f'dac_{i}']]
-            ))
+            self.add(
+                pr.LinkVariable(
+                    name=f"Vdac_{i}",
+                    units="V",
+                    disp="{:1.3f}",  # Only display the 1st 3 decimal points
+                    linkedGet=self.convtFloat,
+                    linkedSet=self.revConvtFloat,
+                    dependencies=[self.variables[f"dac_{i}"]],
+                )
+            )
 
         #####################################
         # Create commands
@@ -71,15 +79,20 @@ class sDacRegisters(pr.Device):
 
     def convtFloat(self, var, read):
         intValue = var.dependencies[0].get(read=read)
-        return float(intValue)*(3.0/65536.0)
+        return float(intValue) * (3.0 / 65536.0)
 
     def revConvtFloat(self, var, value, write):
-        assert 0 <= value <= 3.0, f"Value {value} is outside reference voltage range: 0 V to 2.999 V"
-        intValue = int(value*(65536.0/3.0))
+        assert (
+            0 <= value <= 3.0
+        ), f"Value {value} is outside reference voltage range: 0 V to 2.999 V"
+        intValue = int(value * (65536.0 / 3.0))
         var.dependencies[0].set(value=intValue, write=write)
-        return f'{intValue:04X}'
+        return f"{intValue:04X}"
 
     def frequencyConverter(self):
         def func(dev, var):
-            return '{:.3f} kHz'.format(1/(self.clkPeriod * self._count(var.dependencies)) * 1e-3)
+            return "{:.3f} kHz".format(
+                1 / (self.clkPeriod * self._count(var.dependencies)) * 1e-3
+            )
+
         return func

--- a/python/epix_hr_core/_sDacRegisters.py
+++ b/python/epix_hr_core/_sDacRegisters.py
@@ -44,12 +44,7 @@ class sDacRegisters(pr.Device):
         self.add(
             pr.RemoteVariable(
                 name="dummy",
-                description="",
                 offset=0x00014,
-                bitSize=32,
-                bitOffset=0,
-                base=pr.UInt,
-                disp="{:#x}",
                 mode="RW",
             )
         )

--- a/python/epix_hr_core/_sDacRegisters.py
+++ b/python/epix_hr_core/_sDacRegisters.py
@@ -24,23 +24,39 @@ class sDacRegisters(pr.Device):
         #############################################
 
 
-        #Setup registers & variables
+        # Setup registers & variables
 
-        self.add((
-            pr.RemoteVariable(name='dac_0'  ,         description='',                  offset=0x00000, bitSize=16,   bitOffset=0,   base=pr.UInt, disp = '{:#x}', mode='RW'),
-            pr.RemoteVariable(name='dac_1'  ,         description='',                  offset=0x00004, bitSize=16,   bitOffset=0,   base=pr.UInt, disp = '{:#x}', mode='RW'),
-            pr.RemoteVariable(name='dac_2'  ,         description='',                  offset=0x00008, bitSize=16,   bitOffset=0,   base=pr.UInt, disp = '{:#x}', mode='RW'),
-            pr.RemoteVariable(name='dac_3'  ,         description='',                  offset=0x0000C, bitSize=16,   bitOffset=0,   base=pr.UInt, disp = '{:#x}', mode='RW'),
-            pr.RemoteVariable(name='dac_4'  ,         description='',                  offset=0x00010, bitSize=16,   bitOffset=0,   base=pr.UInt, disp = '{:#x}', mode='RW'),
-            pr.RemoteVariable(name='dummy'  ,         description='',                  offset=0x00014, bitSize=32,   bitOffset=0,   base=pr.UInt, disp = '{:#x}', mode='RW'))
-        )
-        self.add((
-            pr.LinkVariable  (name='Vdac_0' ,        linkedSet=self.revConvtFloat,     linkedGet=self.convtFloat,        dependencies=[self.dac_0]),
-            pr.LinkVariable  (name='Vdac_1' ,        linkedSet=self.revConvtFloat,     linkedGet=self.convtFloat,        dependencies=[self.dac_1]),
-            pr.LinkVariable  (name='Vdac_2' ,        linkedSet=self.revConvtFloat,     linkedGet=self.convtFloat,        dependencies=[self.dac_2]),
-            pr.LinkVariable  (name='Vdac_3' ,        linkedSet=self.revConvtFloat,     linkedGet=self.convtFloat,        dependencies=[self.dac_3]),
-            pr.LinkVariable  (name='Vdac_4' ,        linkedSet=self.revConvtFloat,     linkedGet=self.convtFloat,        dependencies=[self.dac_4]))
-        )
+        # Add Five DAC Registers
+        for i in range(5):
+            self.add(pr.RemoteVariable(
+                name = f'dac_{i}',
+                offset = i * 4,
+                bitSize = 16,
+                bitOffset = 0,
+                base = pr.UInt,
+                disp = '{:#x}',
+                mode = 'RW'))
+        
+        # Add Dummy Register
+        self.add(pr.RemoteVariable(
+        name = 'dummy',         
+        description = '',                  
+        offset = 0x00014, 
+        bitSize = 32,   
+        bitOffset = 0,   
+        base = pr.UInt, 
+        disp = '{:#x}', 
+        mode = 'RW'))
+
+        # Add DAC Voltage Linker Variables
+        for i in range(5):
+            self.add(pr.LinkVariable(
+                name = f'Vdac_{i}',
+                units = 'V',
+                linkedGet = self.convtFloat,
+                linkedSet = self.revConvtFloat,
+                dependencies = [self.variables[f'dac_{i}']]
+            ))
 
         #####################################
         # Create commands
@@ -52,21 +68,15 @@ class sDacRegisters(pr.Device):
         # A command can also be a call to a local function with local scope.
         # The command object and the arg are passed
 
-
-
-    @staticmethod
-    def convtFloat(var, read):
+    def convtFloat(self, var, read):
         intValue = var.dependencies[0].get(read=read)
         return float(intValue)*(3.0/65536.0)
 
-    @staticmethod
-    def revConvtFloat(var, value, write):
+    def revConvtFloat(self, var, value, write):
         assert 0 <= value <= 3.0, f"Value {value} is outside reference voltage range: 0 V to 2.999 V"
         intValue = int(value*(65536.0/3.0))
         var.dependencies[0].set(value=intValue, write=write)
-        return '%04x' % (intValue)
 
-    @staticmethod
     def frequencyConverter(self):
         def func(dev, var):
             return '{:.3f} kHz'.format(1/(self.clkPeriod * self._count(var.dependencies)) * 1e-3)

--- a/python/epix_hr_core/_sDacRegisters.py
+++ b/python/epix_hr_core/_sDacRegisters.py
@@ -53,17 +53,19 @@ class sDacRegisters(pr.Device):
         # The command object and the arg are passed
 
 
-    @staticmethod
-    def convtFloat(dev, var):
-        value   = var.dependencies[0].get(read=False)
-        fpValue = value*(3.0/65536.0)
-        return '%0.3f'%(fpValue)
 
     @staticmethod
-    def revConvtFloat(dev, var):
-        value   = var.dependencies[0].set(read=False)
+    def convtFloat(var, read):
+        intValue = var.dependencies[0].get(read=read)
+        return float(intValue)*(3.0/65536.0)
+
+    @staticmethod
+    def revConvtFloat(var, value, write):
+        assert 0 <= value <= 3.0, f"Value {value} is outside reference voltage range: 0 V to 2.999 V"
         intValue = int(value*(65536.0/3.0))
-        return '%d'%(intValue)
+        var.dependencies[0].set(value=intValue, write=write)
+        return '%04x' % (intValue)
+
 
     @staticmethod
     def frequencyConverter(self):

--- a/python/epix_hr_core/_sDacRegisters.py
+++ b/python/epix_hr_core/_sDacRegisters.py
@@ -53,6 +53,7 @@ class sDacRegisters(pr.Device):
             self.add(pr.LinkVariable(
                 name = f'Vdac_{i}',
                 units = 'V',
+                disp = '{:1.3f}', # Only display the 1st 3 decimal points
                 linkedGet = self.convtFloat,
                 linkedSet = self.revConvtFloat,
                 dependencies = [self.variables[f'dac_{i}']]

--- a/python/epix_hr_core/_sDacRegisters.py
+++ b/python/epix_hr_core/_sDacRegisters.py
@@ -76,6 +76,7 @@ class sDacRegisters(pr.Device):
         assert 0 <= value <= 3.0, f"Value {value} is outside reference voltage range: 0 V to 2.999 V"
         intValue = int(value*(65536.0/3.0))
         var.dependencies[0].set(value=intValue, write=write)
+        return f'{intValue:04X}'
 
     def frequencyConverter(self):
         def func(dev, var):

--- a/python/epix_hr_core/_sDacRegisters.py
+++ b/python/epix_hr_core/_sDacRegisters.py
@@ -83,11 +83,3 @@ class sDacRegisters(pr.Device):
         intValue = int(value * (65536.0 / 3.0))
         var.dependencies[0].set(value=intValue, write=write)
         return f"{intValue:04X}"
-
-    def frequencyConverter(self):
-        def func(dev, var):
-            return "{:.3f} kHz".format(
-                1 / (self.clkPeriod * self._count(var.dependencies)) * 1e-3
-            )
-
-        return func

--- a/python/epix_hr_core/_sDacRegisters.py
+++ b/python/epix_hr_core/_sDacRegisters.py
@@ -63,7 +63,6 @@ class sDacRegisters(pr.Device):
     def revConvtFloat(var, value, write):
         assert 0 <= value <= 3.0, f"Value {value} is outside reference voltage range: 0 V to 2.999 V"
         intValue = int(value*(65536.0/3.0))
-        jpsmith/make-slow-dac-voltage-writable-from-client
         var.dependencies[0].set(value=intValue, write=write)
         return '%04x' % (intValue)
 

--- a/python/epix_hr_core/_sDacRegisters.py
+++ b/python/epix_hr_core/_sDacRegisters.py
@@ -39,13 +39,13 @@ class sDacRegisters(pr.Device):
         
         # Add Dummy Register
         self.add(pr.RemoteVariable(
-        name = 'dummy',         
-        description = '',                  
-        offset = 0x00014, 
-        bitSize = 32,   
-        bitOffset = 0,   
-        base = pr.UInt, 
-        disp = '{:#x}', 
+        name = 'dummy',
+        description = '',
+        offset = 0x00014,
+        bitSize = 32,
+        bitOffset = 0,
+        base = pr.UInt,
+        disp = '{:#x}',
         mode = 'RW'))
 
         # Add DAC Voltage Linker Variables


### PR DESCRIPTION
Fix error in [PR#48](https://github.com/slaclab/epix-hr-core/pull/48) which erroneously included a read argument in the PR set method.

Tested with epix-hr hardware and confirmed it functions as expected.